### PR TITLE
fix: display 0 instead of x for egg count in score board

### DIFF
--- a/.changeset/fix-egg-count-display.md
+++ b/.changeset/fix-egg-count-display.md
@@ -1,0 +1,7 @@
+---
+'eggdrop': patch
+---
+
+Fix egg count in score board starting with "x" instead of "0"
+
+The egg count display in the score board during gameplay now correctly starts at "0" instead of displaying "x" when no eggs have been caught yet.

--- a/src/EggTally/EggTally.tsx
+++ b/src/EggTally/EggTally.tsx
@@ -59,7 +59,7 @@ export function EggTally({
       <Text
         x={eggSize + 8}
         y={0.5 * eggSize - 10}
-        text={count === 0 ? 'x' : count.toLocaleString()}
+        text={count.toLocaleString()}
         fontSize={20}
         fontStyle="bold"
         fontFamily="Arco"


### PR DESCRIPTION
## Description

Fixes the egg count display in the score board during gameplay. Previously, when no eggs had been caught yet, the count would display "x" instead of "0".

## Changes

- Updated `EggTally` component to always display the count using `toLocaleString()` instead of showing "x" when count is 0
- Added changeset for patch version bump

## Testing Steps

1. Start a new game session
2. Observe the score board (both Level Score Box and Game Score Box)
3. Verify that all egg counts (white, gold, black) display "0" instead of "x" at the start of gameplay
4. Catch some eggs and verify the counts increment correctly

## Related Issue

Fixes #192