### PR TITLE
fix: enable CI workflow triggers for Version Packages PR

### DIFF
--- a/.changeset/fix-version-pr-ci-trigger.md
+++ b/.changeset/fix-version-pr-ci-trigger.md
@@ -1,0 +1,5 @@
+---
+"eggdrop": patch
+---
+
+Fix Version Packages PR not triggering CI workflows by supporting PAT token for changesets action

--- a/.github/CHANGESETS_TOKEN_SETUP.md
+++ b/.github/CHANGESETS_TOKEN_SETUP.md
@@ -1,0 +1,67 @@
+# Fix: Version Packages PR Not Triggering CI
+
+## Problem
+
+The "Version Packages" PR (created by changesets) doesn't automatically trigger CI workflows because GitHub Actions using `GITHUB_TOKEN` intentionally don't trigger workflows on PRs they create/update (prevents infinite loops).
+
+## Solution
+
+Use a Personal Access Token (PAT) instead of `GITHUB_TOKEN` for the changesets action.
+
+## Setup Steps
+
+### 1. Create a Personal Access Token
+
+1. Go to GitHub Settings → Developer settings → Personal access tokens → Fine-grained tokens
+2. Click "Generate new token"
+3. Configure the token:
+   - **Name**: `Changesets Workflow Token`
+   - **Expiration**: 90 days (or custom)
+   - **Repository access**: Only select repositories → `eggdrop`
+   - **Permissions**:
+     - Contents: Read and write
+     - Pull requests: Read and write
+     - Workflows: Read and write (allows triggering workflows)
+4. Generate token and copy it
+
+### 2. Add Token to Repository Secrets
+
+1. Go to Repository Settings → Secrets and variables → Actions
+2. Click "New repository secret"
+3. **Name**: `CHANGESETS_TOKEN`
+4. **Value**: Paste the token you created
+5. Save
+
+### 3. Workflow Already Updated
+
+The `version.yml` workflow has been updated to use `CHANGESETS_TOKEN` with fallback to `GITHUB_TOKEN`:
+
+```yaml
+env:
+  GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN || secrets.GITHUB_TOKEN }}
+```
+
+## Verification
+
+After adding the secret:
+
+1. Merge a PR with a changeset to `dev`
+2. The Version workflow will run and update the "Version Packages" PR
+3. CI workflow should now automatically trigger on the PR update
+4. Check that "Verify Build" status appears on the PR
+
+## Alternative: Manual Trigger
+
+If you prefer not to use a PAT, you can manually trigger CI:
+
+```bash
+gh workflow run ci.yml --ref changeset-release/dev
+```
+
+Or simply close and reopen the PR to trigger CI.
+
+## Token Maintenance
+
+- PATs expire - you'll need to regenerate and update the secret periodically
+- GitHub will email you when the token is about to expire
+- Consider setting a calendar reminder to regenerate the token

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -39,4 +39,6 @@ jobs:
         with:
           version: pnpm run version
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use PAT to trigger CI workflows on PR updates
+          # Falls back to GITHUB_TOKEN if PAT not available
+          GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes the issue where the "Version Packages" PR doesn't automatically trigger CI workflows.

## Problem

When GitHub Actions creates or updates PRs using `GITHUB_TOKEN`, it intentionally does not trigger workflow runs on those PRs to prevent infinite loops. This is why PR #201 (and future Version Packages PRs) don't automatically run CI checks.

## Solution

Updated the `version.yml` workflow to support using a Personal Access Token (PAT) via `CHANGESETS_TOKEN` secret, with fallback to `GITHUB_TOKEN`.

## Changes

- Updated `.github/workflows/version.yml` to use `CHANGESETS_TOKEN || GITHUB_TOKEN`
- Added `.github/CHANGESETS_TOKEN_SETUP.md` with detailed setup instructions
- Includes changeset for version tracking

## Test plan

**Without PAT (current behavior):**
- [x] Manually triggered CI for PR #201 to verify it passes
- [ ] User can continue using manual triggers: `gh workflow run ci.yml --ref changeset-release/dev`

**With PAT (after setup):**
- [ ] Follow setup instructions in `CHANGESETS_TOKEN_SETUP.md`
- [ ] Merge a PR with changeset to dev
- [ ] Verify Version Packages PR automatically triggers CI

## References

Closes #201 (workaround provided, full fix requires PAT setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)