### PR TITLE
fix: correct Vercel routing to serve static assets

### DIFF
--- a/.changeset/fix-vercel-asset-routing.md
+++ b/.changeset/fix-vercel-asset-routing.md
@@ -1,0 +1,5 @@
+---
+"eggdrop": patch
+---
+
+Fix Vercel routing to serve static assets correctly. Add filesystem handler to prevent redirecting JS/CSS files to index.html

--- a/vercel.json
+++ b/vercel.json
@@ -21,6 +21,12 @@
     }
   ],
   "routes": [
-    { "src": "/(.*)", "dest": "/index.html" }
+    {
+      "handle": "filesystem"
+    },
+    {
+      "src": "/(.*)",
+      "dest": "/index.html"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes the app failing to load due to incorrect Vercel routing configuration.

## Problem

The current `vercel.json` configuration redirects ALL requests to `index.html`, including requests for JavaScript modules, CSS files, and other static assets. This causes the browser to receive HTML content when it expects JavaScript, resulting in:

```
Failed to load module script: Expected a JavaScript module but the server responded with a MIME type of "text/html"
```

## Solution

Add `"handle": "filesystem"` as the first route rule to check for actual files before falling back to `index.html` for SPA routing.

## Changes

**Before:**
```json
"routes": [
  { "src": "/(.*)", "dest": "/index.html" }
]
```

**After:**
```json
"routes": [
  { "handle": "filesystem" },
  { "src": "/(.*)", "dest": "/index.html" }
]
```

## How it works

1. First, Vercel checks if the requested path matches an actual file in the `dist` folder
2. If a file exists (JS, CSS, images, etc.), serve it directly
3. If no file exists, redirect to `index.html` for client-side routing

## Test plan

- [x] Review Vercel routing configuration
- [ ] Deploy preview and verify:
  - [ ] App loads without module script errors
  - [ ] Static assets (JS, CSS, images) load correctly
  - [ ] Client-side routing still works (refresh on any route)
  - [ ] Direct URL navigation to routes works

## Impact

Critical fix - the app is currently broken in production due to this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)