### PR TITLE
feat: add automatic GitHub Release creation on promote to main

### DIFF
--- a/.changeset/github-releases.md
+++ b/.changeset/github-releases.md
@@ -2,4 +2,4 @@
 "eggdrop": patch
 ---
 
-Add automatic GitHub Release creation when promoting to main. Releases are created with version tags (v0.x.x) and changelog content extracted from CHANGELOG.md.
+Rename promote-to-main workflow to auto-promote-and-release and add automatic GitHub Release creation. Releases are created with version tags (v0.x.x) and changelog content extracted from CHANGELOG.md.

--- a/.changeset/github-releases.md
+++ b/.changeset/github-releases.md
@@ -1,0 +1,5 @@
+---
+"eggdrop": patch
+---
+
+Add automatic GitHub Release creation when promoting to main. Releases are created with version tags (v0.x.x) and changelog content extracted from CHANGELOG.md.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -30,7 +30,9 @@
       "Bash(pnpm changeset:*)",
       "Bash(source ~/.nvm/nvm.sh)",
       "Bash(nvm use:*)",
-      "Bash(pnpm exec playwright test:*)"
+      "Bash(pnpm exec playwright test:*)",
+      "Bash(git push:*)",
+      "Bash(npm install:*)"
     ],
     "deny": [],
     "ask": []

--- a/.github/workflows/auto-promote-and-release.yml
+++ b/.github/workflows/auto-promote-and-release.yml
@@ -1,6 +1,6 @@
 # Automatically merges dev into main after a "Version Packages" PR is merged
-# This completes the release process - Vercel will auto-deploy main to production
-name: Promote to Main
+# Creates a GitHub Release with changelog, then Vercel auto-deploys main to production
+name: Auto Promote and Release
 
 on:
   pull_request:
@@ -10,8 +10,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  promote:
-    name: Merge dev to main
+  promote-and-release:
+    name: Promote to main and create release
     runs-on: ubuntu-latest
     # Only run if PR was merged (not just closed) AND is a Version Packages PR
     # For workflow_dispatch, always run

--- a/.github/workflows/promote-to-main.yml
+++ b/.github/workflows/promote-to-main.yml
@@ -40,7 +40,52 @@ jobs:
           git merge origin/dev --no-edit
           git push origin main
 
+      - name: Get version from package.json
+        id: get-version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Check if tag exists
+        id: tag-check
+        run: |
+          if git rev-parse "v${{ steps.get-version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create and push tag
+        if: steps.tag-check.outputs.exists == 'false'
+        run: |
+          git tag "v${{ steps.get-version.outputs.version }}"
+          git push origin "v${{ steps.get-version.outputs.version }}"
+
+      - name: Extract changelog for this version
+        if: steps.tag-check.outputs.exists == 'false'
+        id: changelog
+        run: |
+          VERSION="${{ steps.get-version.outputs.version }}"
+          # Extract content between this version header and the next version header
+          CHANGELOG=$(sed -n "/^## ${VERSION}$/,/^## [0-9]/p" CHANGELOG.md | sed '$d' | tail -n +2)
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo "$CHANGELOG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        if: steps.tag-check.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.get-version.outputs.version }}
+          name: v${{ steps.get-version.outputs.version }}
+          body: ${{ steps.changelog.outputs.content }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Summary
         run: |
           echo "✅ Successfully merged dev into main"
           echo "🚀 Vercel will now deploy to production"
+          if [ "${{ steps.tag-check.outputs.exists }}" == "false" ]; then
+            echo "📦 Created GitHub Release v${{ steps.get-version.outputs.version }}"
+          else
+            echo "⏭️ Skipped release creation (tag v${{ steps.get-version.outputs.version }} already exists)"
+          fi


### PR DESCRIPTION
## Summary
- Adds automatic GitHub Release creation when code is promoted to main branch
- Creates version tags (v0.x.x) and populates release notes from CHANGELOG.md
- Includes idempotency check to skip if tag already exists

## Test plan
- [ ] Merge this PR to dev
- [ ] Merge the resulting Version Packages PR
- [ ] Verify promote-to-main workflow creates a GitHub Release
- [ ] Check the Releases section shows the new release with changelog content

🤖 Generated with [Claude Code](https://claude.com/claude-code)